### PR TITLE
fix typo from linx-64 to linux-64

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,5 +30,5 @@ make windows
 make windows-64
 make mac-64
 make linux
-make linx-64
+make linux-64
 ```


### PR DESCRIPTION
just fixing a typo in the readme
